### PR TITLE
correct file - validation.yml

### DIFF
--- a/locale/validation.yml
+++ b/locale/validation.yml
@@ -1,3 +1,18 @@
+validation:
+  accepted: "O :attribute deve ser aceito."
+  active_url: "O :attribute Não é uma URL válida."
+  after: "O :attribute deve ser uma data após :date."
+  alpha: "O :attribute pode conter apenas letras."
+  alpha_dash: "O :attribute pode apenas conter letras, números e traços."
+  alpha_num: "O :attribute pode apenas conter letras e números."
+  array: "O :attribute deve ser uma array."
+  before: "O :attribute deve ser uma data antes de :date."
+  between:
+    numeric: "O :attribute deve estar entre :min e :max."
+    file: "O :attribute deve ser entre :min e :max kilobytes."
+    string: "O :attribute deve ser entre :min e :max caracteres."
+    array: "O :attribute deve ter entre :min e :max items."
+  boolean: "O campo :attribute deve ser verdadeiro ou falso."
   confirmed: "A confirmação de :attribute não combina."
   date: "o :attribute não é uma data válida."
   date_format: "O :attribute não combina com o formato :other."
@@ -22,7 +37,7 @@
     string: "O :attribute não pode ser maior do que :max caracteres."
     array: "O :attribute não pode ter mais do que :max ítens."
   mimes: "O :attribute deve ser um arquivo do tipo: :values."
-mimetypes: "O :attribute deve ser um ficheiro do tipo: :values."
+  mimetypes: "O :attribute deve ser um ficheiro do tipo: :values."
   min:
     numeric: "O :attribute deve ter no mínimo :min."
     file: "O :attribute deve ter no mínimo :min kilobytes."


### PR DESCRIPTION
overcome error upon language change to Portuguese

Error parsing YAML, invalid file "........./flarum-portuguese/locale/validation.yml"

added missing labels and correct indentation in file